### PR TITLE
c header

### DIFF
--- a/apps/nvlink_shared/src/Raytracer.cpp
+++ b/apps/nvlink_shared/src/Raytracer.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <cstring>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
fix error: ‘memset’ was not declared in this scope